### PR TITLE
Move Monome.disconnect to aiosc.OSCProtocol

### DIFF
--- a/monome.py
+++ b/monome.py
@@ -69,9 +69,6 @@ class Monome(aiosc.OSCProtocol):
         self.send('/sys/prefix', self.prefix)
         self.send('/sys/info', self.host, self.port)
 
-    def disconnect(self):
-        self.transport.close()
-
     def sys_info(self, addr, path, *args):
         if path == '/sys/id':
             self.id = args[0]


### PR DESCRIPTION
I believe this was the intention all along and allows you to properly
call disconnect (and close the underlying transport) on the SerialOSC
instance returned by create_serialosc_connection.

This goes in hand with 2efb3a9c93e8b5d8bbe737c67185a3ef25f6cc4d on
aiosc.